### PR TITLE
Resolvendo verificador de palíndromo

### DIFF
--- a/src/br/com/logicaprogramacao/Palindrono.java
+++ b/src/br/com/logicaprogramacao/Palindrono.java
@@ -2,17 +2,35 @@ package br.com.logicaprogramacao;
 
 public class Palindrono {
 
-    public String validarPalindromo(String palavra) {
+    public void validarPalindromo(String palavra) {
         if (checarPalindromo(palavra)) {
-            return String.format("A palavra %s é um palíndromo");
+            System.out.printf("A palavra %s é um palíndromo\n", palavra);
         } else {
-            return String.format("A palavra %s não é um palíndromo");
+            System.out.printf("A palavra %s não é um palíndromo\n", palavra);
         }
     }
 
     private boolean checarPalindromo(String palavra) {
-        //TODO implementar logica
-        return false;
-    }
+        palavra = palavra.trim().toLowerCase();
 
+        char[] inicial = palavra.toCharArray();
+        int qntCaracteres = inicial.length;
+
+        char[] contrario = new char[qntCaracteres];
+
+        for (int i = qntCaracteres - 1, j = 0; i >= 0; i--) {
+            if (Character.isLetter(inicial[i])) {
+                contrario[j] = inicial[i];
+                j++;
+            }
+        }
+
+        for (int i = 0; i < qntCaracteres; i++) {
+            if (inicial[i] != contrario[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Precisei trocar o método validarPalindromo porque o String.format estava dando um erro de encoding no meu PC e não imprimia de jeito nenhum.
Agora é um método void, e ao invés de retornar uma String, ele printa o resultado da verificação.